### PR TITLE
WIP: Fuse activation templates into expression-backed layers

### DIFF
--- a/DeepLearning/Api/Layers/Activations/Activation.cpp
+++ b/DeepLearning/Api/Layers/Activations/Activation.cpp
@@ -1,5 +1,7 @@
 #include "DeepLearning/Api/Layers/Activations/Activation.h"
 
+#include <stdexcept>
+
 using namespace std;
 using json = nlohmann::json;
 
@@ -13,7 +15,67 @@ unordered_map<string, Activation::Deserializer>& Activation::get_registry() {
 void Activation::register_layer(string name, Deserializer fn) { get_registry().emplace(std::move(name), std::move(fn)); }
 
 ThorImplementation::Expression Activation::toExpression(const ThorImplementation::Expression& input) const {
-    (void)input;
+    using ThorImplementation::Expression;
+
+    const string layerType = getLayerType();
+
+    if (layerType == "Relu") {
+        return input.max(0.0);
+    }
+
+    if (layerType == "Sigmoid") {
+        Expression one(1.0);
+        return one / (one + (-input).exp());
+    }
+
+    if (layerType == "Tanh") {
+        const Expression exp2x = (input * 2.0).exp();
+        return (exp2x - 1.0) / (exp2x + 1.0);
+    }
+
+    if (layerType == "HardSigmoid") {
+        return ((input * 0.2) + 0.5).min(1.0).max(0.0);
+    }
+
+    if (layerType == "SoftPlus") {
+        return (input.exp() + 1.0).ln();
+    }
+
+    if (layerType == "SoftSign") {
+        return input / (input.abs() + 1.0);
+    }
+
+    if (layerType == "Exponential") {
+        return input.exp();
+    }
+
+    if (layerType == "Gelu") {
+        // Match the existing CUDA activation approximation:
+        // 0.5 * x * (1 + tanh(sqrt(2 / pi) * (x + 0.044715 * x^3))).
+        const Expression x3 = input * input * input;
+        const Expression inner = (input + (x3 * 0.044715)) * 0.797884561;
+        const Expression exp2Inner = (inner * 2.0).exp();
+        const Expression tanhInner = (exp2Inner - 1.0) / (exp2Inner + 1.0);
+        return input * 0.5 * (tanhInner + 1.0);
+    }
+
+    if (layerType == "Selu") {
+        constexpr double scale = 1.05070098;
+        constexpr double scaleAlpha = 1.758099326;
+        return (input.max(0.0) * scale) + ((input.exp() - 1.0).min(0.0) * scaleAlpha);
+    }
+
+    if (layerType == "Swish") {
+        Expression one(1.0);
+        return input * (one / (one + (-input).exp()));
+    }
+
+    if (layerType == "Softmax") {
+        const Expression shifted = input - input.reduce_max({1}, {});
+        const Expression expShifted = shifted.exp();
+        return expShifted / expShifted.reduce_sum({1}, {});
+    }
+
     throw std::runtime_error("Activation " + getLayerType() + " does not support expression fusion.");
 }
 

--- a/DeepLearning/Api/Layers/Activations/Activation.cpp
+++ b/DeepLearning/Api/Layers/Activations/Activation.cpp
@@ -17,32 +17,34 @@ void Activation::register_layer(string name, Deserializer fn) { get_registry().e
 ThorImplementation::Expression Activation::toExpression(const ThorImplementation::Expression& input) const {
     using ThorImplementation::Expression;
 
+    const Expression zero(0.0);
+    const Expression one(1.0);
+    const Expression two(2.0);
     const string layerType = getLayerType();
 
     if (layerType == "Relu") {
-        return input.max(0.0);
+        return input.max(zero);
     }
 
     if (layerType == "Sigmoid") {
-        Expression one(1.0);
         return one / (one + (-input).exp());
     }
 
     if (layerType == "Tanh") {
-        const Expression exp2x = (input * 2.0).exp();
-        return (exp2x - 1.0) / (exp2x + 1.0);
+        const Expression exp2x = (input * two).exp();
+        return (exp2x - one) / (exp2x + one);
     }
 
     if (layerType == "HardSigmoid") {
-        return ((input * 0.2) + 0.5).min(1.0).max(0.0);
+        return ((input * Expression(0.2)) + Expression(0.5)).min(one).max(zero);
     }
 
     if (layerType == "SoftPlus") {
-        return (input.exp() + 1.0).ln();
+        return (input.exp() + one).ln();
     }
 
     if (layerType == "SoftSign") {
-        return input / (input.abs() + 1.0);
+        return input / (input.abs() + one);
     }
 
     if (layerType == "Exponential") {
@@ -53,20 +55,19 @@ ThorImplementation::Expression Activation::toExpression(const ThorImplementation
         // Match the existing CUDA activation approximation:
         // 0.5 * x * (1 + tanh(sqrt(2 / pi) * (x + 0.044715 * x^3))).
         const Expression x3 = input * input * input;
-        const Expression inner = (input + (x3 * 0.044715)) * 0.797884561;
-        const Expression exp2Inner = (inner * 2.0).exp();
-        const Expression tanhInner = (exp2Inner - 1.0) / (exp2Inner + 1.0);
-        return input * 0.5 * (tanhInner + 1.0);
+        const Expression inner = (input + (x3 * Expression(0.044715))) * Expression(0.797884561);
+        const Expression exp2Inner = (inner * two).exp();
+        const Expression tanhInner = (exp2Inner - one) / (exp2Inner + one);
+        return input * Expression(0.5) * (tanhInner + one);
     }
 
     if (layerType == "Selu") {
-        constexpr double scale = 1.05070098;
-        constexpr double scaleAlpha = 1.758099326;
-        return (input.max(0.0) * scale) + ((input.exp() - 1.0).min(0.0) * scaleAlpha);
+        const Expression scale(1.05070098);
+        const Expression scaleAlpha(1.758099326);
+        return (input.max(zero) * scale) + ((input.exp() - one).min(zero) * scaleAlpha);
     }
 
     if (layerType == "Swish") {
-        Expression one(1.0);
         return input * (one / (one + (-input).exp()));
     }
 

--- a/DeepLearning/Api/Layers/Activations/Activation.cpp
+++ b/DeepLearning/Api/Layers/Activations/Activation.cpp
@@ -12,6 +12,11 @@ unordered_map<string, Activation::Deserializer>& Activation::get_registry() {
 
 void Activation::register_layer(string name, Deserializer fn) { get_registry().emplace(std::move(name), std::move(fn)); }
 
+ThorImplementation::Expression Activation::toExpression(const ThorImplementation::Expression& input) const {
+    (void)input;
+    throw std::runtime_error("Activation " + getLayerType() + " does not support expression fusion.");
+}
+
 json Activation::architectureJson() const {
     assert(initialized);
     assert(featureInput.isPresent());

--- a/DeepLearning/Api/Layers/Activations/Activation.h
+++ b/DeepLearning/Api/Layers/Activations/Activation.h
@@ -2,6 +2,7 @@
 
 #include "DeepLearning/Api/Layers/Layer.h"
 #include "DeepLearning/Api/Network/Network.h"
+#include "Utilities/Expression/Expression.h"
 
 #include <assert.h>
 #include <atomic>
@@ -22,6 +23,10 @@ class Activation : public Layer {
     using Layer::addToNetwork;
     // Activation template version
     virtual Tensor addToNetwork(Tensor inputTensor, Network* network);
+
+    // Returns an expression equivalent to applying this activation to the input expression.
+    // This is used by expression-backed learning layers to fuse the activation into the layer equation.
+    virtual ThorImplementation::Expression toExpression(const ThorImplementation::Expression& input) const = 0;
 
     virtual std::string getLayerType() const = 0;
 

--- a/DeepLearning/Api/Layers/Activations/Activation.h
+++ b/DeepLearning/Api/Layers/Activations/Activation.h
@@ -26,7 +26,7 @@ class Activation : public Layer {
 
     // Returns an expression equivalent to applying this activation to the input expression.
     // This is used by expression-backed learning layers to fuse the activation into the layer equation.
-    virtual ThorImplementation::Expression toExpression(const ThorImplementation::Expression& input) const = 0;
+    virtual ThorImplementation::Expression toExpression(const ThorImplementation::Expression& input) const;
 
     virtual std::string getLayerType() const = 0;
 

--- a/DeepLearning/Api/Layers/Activations/Elu.h
+++ b/DeepLearning/Api/Layers/Activations/Elu.h
@@ -18,6 +18,12 @@ class Elu : public Activation {
         return myClone;
     }
 
+    virtual ThorImplementation::Expression toExpression(const ThorImplementation::Expression& input) const override {
+        const ThorImplementation::Expression zero(0.0);
+        const ThorImplementation::Expression one(1.0);
+        return input.max(zero) + ((input.exp() - one).min(zero) * ThorImplementation::Expression(alpha));
+    }
+
     virtual std::string getLayerType() const { return "Elu"; }
 
     virtual nlohmann::json architectureJson() const {

--- a/DeepLearning/Api/Layers/Activations/Relu.h
+++ b/DeepLearning/Api/Layers/Activations/Relu.h
@@ -18,7 +18,9 @@ class Relu : public Activation {
         return myClone;
     }
 
-    virtual ThorImplementation::Expression toExpression(const ThorImplementation::Expression& input) const { return input.max(0.0); }
+    virtual ThorImplementation::Expression toExpression(const ThorImplementation::Expression& input) const override {
+        return input.max(ThorImplementation::Expression(0.0));
+    }
 
     virtual std::string getLayerType() const { return "Relu"; }
 

--- a/DeepLearning/Api/Layers/Activations/Relu.h
+++ b/DeepLearning/Api/Layers/Activations/Relu.h
@@ -18,6 +18,8 @@ class Relu : public Activation {
         return myClone;
     }
 
+    virtual ThorImplementation::Expression toExpression(const ThorImplementation::Expression& input) const { return input.max(0.0); }
+
     virtual std::string getLayerType() const { return "Relu"; }
 
     static void deserialize(const nlohmann::json &j, Network *network) {

--- a/DeepLearning/Api/Layers/Learning/FullyConnected.h
+++ b/DeepLearning/Api/Layers/Learning/FullyConnected.h
@@ -51,7 +51,7 @@ class FullyConnected : public TrainableLayer {
    protected:
     virtual bool isMultiLayer() const {
         assert(featureInputs.size() > 0);
-        return useBatchNormalization || dropProportion > 0.0f || activation || featureInputs.front().getDimensions().size() > 1 ||
+        return useBatchNormalization || dropProportion > 0.0f || featureInputs.front().getDimensions().size() > 1 ||
                featureInputs.front().getDataType() != Tensor::DataType::FP16;
     }
 
@@ -109,8 +109,16 @@ class FullyConnected : public TrainableLayer {
         // Note: Network notes when a layer has already been stamped and only adds a connection, does not re-stamp the layer
         // FIXME: add support for data type.
         Tensor::DataType weightsDataType = Tensor::DataType::FP16;
+        ThorImplementation::FullyConnected::ExpressionTransform activationTransform = nullptr;
+        if (activation != nullptr) {
+            std::shared_ptr<Activation> activationTemplate = activation;
+            activationTransform = [activationTemplate](const ThorImplementation::Expression &input) {
+                return activationTemplate->toExpression(input);
+            };
+        }
+
         std::shared_ptr<ThorImplementation::FullyConnected> physicalFullyConnected = std::make_shared<ThorImplementation::FullyConnected>(
-            numOutputFeatures, hasBias, weightsDataType, placement, inferenceOnly, getId());
+            numOutputFeatures, hasBias, weightsDataType, placement, inferenceOnly, getId(), activationTransform);
 
         return physicalFullyConnected;
     }

--- a/DeepLearning/Implementation/Layers/NeuralNetwork/FullyConnected.cpp
+++ b/DeepLearning/Implementation/Layers/NeuralNetwork/FullyConnected.cpp
@@ -56,18 +56,19 @@ FullyConnected::FullyConnected(const uint32_t numOutputFeatures,
                                Optional<DataType> weightsDataType,
                                const TensorPlacement& placement,
                                bool inferenceOnly,
-                               int64_t stampedId)
-    : CustomLayer(buildExpression(hasBias, placement),
+                               int64_t stampedId,
+                               ExpressionTransform activation)
+    : CustomLayer(buildExpression(hasBias, placement, std::move(activation)),
                   placement,
                   defineParameters(numOutputFeatures, hasBias, weightsDataType),
                   inferenceOnly,
                   stampedId,
                   false) {}
 
-DynamicExpression FullyConnected::buildExpression(bool hasBias, TensorPlacement placement) {
-    return DynamicExpression([hasBias, placement](const DynamicExpression::TensorMap& inputs,
-                                                  const DynamicExpression::TensorMap& outputs,
-                                                  Stream& stream) -> DynamicExpressionBuild {
+DynamicExpression FullyConnected::buildExpression(bool hasBias, TensorPlacement placement, ExpressionTransform activation) {
+    return DynamicExpression([hasBias, placement, activation = std::move(activation)](const DynamicExpression::TensorMap& inputs,
+                                                                                     const DynamicExpression::TensorMap& outputs,
+                                                                                     Stream& stream) -> DynamicExpressionBuild {
         (void)stream;
 
         // This is just validation. CustomLayer connects the proper tensors with the contracted names,
@@ -104,6 +105,10 @@ DynamicExpression FullyConnected::buildExpression(bool hasBias, TensorPlacement 
 
             // Broadcast [out_features] over batch
             fout = fout + b;
+        }
+
+        if (activation) {
+            fout = activation(fout);
         }
 
         auto expressionOutputs = Expression::outputs({{"feature_output", fout}});

--- a/DeepLearning/Implementation/Layers/NeuralNetwork/FullyConnected.h
+++ b/DeepLearning/Implementation/Layers/NeuralNetwork/FullyConnected.h
@@ -2,15 +2,19 @@
 
 #include "DeepLearning/Implementation/Layers/CustomLayer.h"
 #include "DeepLearning/Implementation/Parameter/PhysicalParameter.h"
+#include "Utilities/Expression/Expression.h"
 #include "Utilities/TensorOperations/DeepLearning/Add1dBias.h"
 #include "Utilities/TensorOperations/Misc/BatchReduce.h"
 
+#include <functional>
 #include <memory>
 
 namespace ThorImplementation {
 
 class FullyConnected : public CustomLayer {
    public:
+    using ExpressionTransform = std::function<Expression(const Expression&)>;
+
     ~FullyConnected() override = default;
 
     FullyConnected(const uint32_t numOutputFeatures,
@@ -18,12 +22,13 @@ class FullyConnected : public CustomLayer {
                    Optional<TensorDescriptor::DataType> weightsDataType,
                    const TensorPlacement& placement,
                    bool inferenceOnly,
+                   ExpressionTransform activation = nullptr,
                    int64_t stampedId = -1);
 
     std::string getLayerType() override { return "FullyConnected"; }
 
    private:
-    static DynamicExpression buildExpression(bool hasBias, TensorPlacement placement);
+    static DynamicExpression buildExpression(bool hasBias, TensorPlacement placement, ExpressionTransform activation);
     std::vector<std::shared_ptr<PhysicalParameter>> defineParameters(uint32_t numOutputFeatures,
                                                                      bool hasBias,
                                                                      Optional<TensorDescriptor::DataType> weightsDataType);

--- a/DeepLearning/Implementation/Layers/NeuralNetwork/FullyConnected.h
+++ b/DeepLearning/Implementation/Layers/NeuralNetwork/FullyConnected.h
@@ -22,8 +22,8 @@ class FullyConnected : public CustomLayer {
                    Optional<TensorDescriptor::DataType> weightsDataType,
                    const TensorPlacement& placement,
                    bool inferenceOnly,
-                   ExpressionTransform activation = nullptr,
-                   int64_t stampedId = -1);
+                   int64_t stampedId = -1,
+                   ExpressionTransform activation = nullptr);
 
     std::string getLayerType() override { return "FullyConnected"; }
 

--- a/Utilities/Expression/Expression.h
+++ b/Utilities/Expression/Expression.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -239,6 +240,16 @@ class Expression {
         Optional<TensorDescriptor::DataType> compute_dtype = Optional<TensorDescriptor::DataType>::empty(),
         Optional<TensorDescriptor::DataType> output_dtype = Optional<TensorDescriptor::DataType>::empty());
     [[nodiscard]] static Expression constantScalar(double value);
+
+    [[nodiscard]] static Expression fromPhysicalNode(std::shared_ptr<PhysicalExpression> expr, uint32_t nodeIndex) {
+        if (!expr) {
+            throw std::invalid_argument("Expression::fromPhysicalNode requires a non-null PhysicalExpression.");
+        }
+        if (nodeIndex >= expr->nodes.size()) {
+            throw std::out_of_range("Expression::fromPhysicalNode node index is out of range.");
+        }
+        return Expression(std::move(expr), nodeIndex);
+    }
 
     [[nodiscard]] PhysicalExpression expression() const;
 


### PR DESCRIPTION
## Summary

This draft PR starts the activation-expression fusion refactor for the API-side layer work.

Changes included:
- Adds `Activation::toExpression(const ThorImplementation::Expression&)`.
- Implements expression equivalents for the existing activation templates:
  - ReLU
  - ELU, including its per-instance `alpha`
  - Sigmoid
  - Tanh
  - HardSigmoid
  - SoftPlus
  - SoftSign
  - Exponential
  - GELU, matching the existing tanh approximation
  - SELU
  - Swish
  - Softmax over axis 1
- Updates `ThorImplementation::FullyConnected` to accept an optional expression transform and apply it directly to the FC expression after bias addition.
- Updates API `FullyConnected` so activation alone no longer forces the multi-layer path; for the common already-flat FP16 case, activation is passed into the implementation FC expression and can fuse with bias/epilogue work.
- Adds a small `Expression::fromPhysicalNode(...)` helper for future generic expression stitching work.

## Notes / follow-up

This is intentionally marked draft. I did not finish the generic `Thor::CustomLayer::Builder::activation(...)` path yet. The current PR proves the shape for expression-backed FC and adds the activation-to-expression surface needed for CustomLayer fusion, but arbitrary serializable CustomLayer output stitching still needs the builder/member plumbing.

I also could not compile or run the Thor tests from this environment, so this needs a local build/test pass. Two areas I would verify first:
- Whether scalar `Expression` constants and binary ops compile exactly as used in the new activation formulas.
- Whether the softmax expression shape/broadcast behavior matches the existing cuDNN softmax behavior for `[batch, channels]` tensors.