### PR TITLE
Stabilize activation expression fusion formulas

### DIFF
--- a/DeepLearning/Api/Layers/Activations/Activation.cpp
+++ b/DeepLearning/Api/Layers/Activations/Activation.cpp
@@ -19,7 +19,6 @@ ThorImplementation::Expression Activation::toExpression(const ThorImplementation
 
     const Expression zero(0.0);
     const Expression one(1.0);
-    const Expression two(2.0);
     const string layerType = getLayerType();
 
     if (layerType == "Relu") {
@@ -27,12 +26,11 @@ ThorImplementation::Expression Activation::toExpression(const ThorImplementation
     }
 
     if (layerType == "Sigmoid") {
-        return one / (one + (-input).exp());
+        return input.sigmoid();
     }
 
     if (layerType == "Tanh") {
-        const Expression exp2x = (input * two).exp();
-        return (exp2x - one) / (exp2x + one);
+        return input.tanh();
     }
 
     if (layerType == "HardSigmoid") {
@@ -40,7 +38,7 @@ ThorImplementation::Expression Activation::toExpression(const ThorImplementation
     }
 
     if (layerType == "SoftPlus") {
-        return (input.exp() + one).ln();
+        return input.softplus();
     }
 
     if (layerType == "SoftSign") {
@@ -52,23 +50,15 @@ ThorImplementation::Expression Activation::toExpression(const ThorImplementation
     }
 
     if (layerType == "Gelu") {
-        // Match the existing CUDA activation approximation:
-        // 0.5 * x * (1 + tanh(sqrt(2 / pi) * (x + 0.044715 * x^3))).
-        const Expression x3 = input * input * input;
-        const Expression inner = (input + (x3 * Expression(0.044715))) * Expression(0.797884561);
-        const Expression exp2Inner = (inner * two).exp();
-        const Expression tanhInner = (exp2Inner - one) / (exp2Inner + one);
-        return input * Expression(0.5) * (tanhInner + one);
+        return input.gelu();
     }
 
     if (layerType == "Selu") {
-        const Expression scale(1.05070098);
-        const Expression scaleAlpha(1.758099326);
-        return (input.max(zero) * scale) + ((input.exp() - one).min(zero) * scaleAlpha);
+        return input.selu();
     }
 
     if (layerType == "Swish") {
-        return input * (one / (one + (-input).exp()));
+        return input.swish();
     }
 
     if (layerType == "Softmax") {

--- a/DeepLearning/Api/Layers/Activations/Elu.h
+++ b/DeepLearning/Api/Layers/Activations/Elu.h
@@ -19,9 +19,7 @@ class Elu : public Activation {
     }
 
     virtual ThorImplementation::Expression toExpression(const ThorImplementation::Expression& input) const override {
-        const ThorImplementation::Expression zero(0.0);
-        const ThorImplementation::Expression one(1.0);
-        return input.max(zero) + ((input.exp() - one).min(zero) * ThorImplementation::Expression(alpha));
+        return input.elu(alpha);
     }
 
     virtual std::string getLayerType() const { return "Elu"; }

--- a/Utilities/Expression/Expression.h
+++ b/Utilities/Expression/Expression.h
@@ -274,6 +274,17 @@ class Expression {
     [[nodiscard]] Expression squeeze(const std::vector<uint64_t>& squeeze_axes) const;
     [[nodiscard]] Expression transpose() const;
     [[nodiscard]] Expression pow(const Expression& exponent) const;
+
+    // Numerically stable activation-shaped expression helpers built from existing primitive expression ops.
+    // These avoid overflow-prone expansions such as exp(2x) for tanh or log(1 + exp(x)) for softplus.
+    [[nodiscard]] Expression sigmoid() const;
+    [[nodiscard]] Expression tanh() const;
+    [[nodiscard]] Expression softplus() const;
+    [[nodiscard]] Expression elu(double alpha = 1.0) const;
+    [[nodiscard]] Expression selu() const;
+    [[nodiscard]] Expression gelu() const;
+    [[nodiscard]] Expression swish() const;
+
     [[nodiscard]] static Expression matmul(
         const Expression& lhs,
         const Expression& rhs,
@@ -381,6 +392,60 @@ class Expression {
                                                        std::unordered_map<std::string, uint32_t>& dst_input_slots_by_name,
                                                        double& scale_fp);
 };
+
+inline Expression Expression::sigmoid() const {
+    const Expression zero(0.0);
+    const Expression one(1.0);
+
+    // Stable for both signs:
+    //   x >= 0: 1 / (1 + exp(-x))
+    //   x <  0: exp(x) / (1 + exp(x))
+    const Expression numerator = (-(-*this).max(zero)).exp();
+    const Expression denominator = one + (-this->abs()).exp();
+    return numerator / denominator;
+}
+
+inline Expression Expression::tanh() const {
+    return (Expression(2.0) * ((*this * Expression(2.0)).sigmoid())) - Expression(1.0);
+}
+
+inline Expression Expression::softplus() const {
+    const Expression zero(0.0);
+    const Expression one(1.0);
+
+    // log(1 + exp(x)) = max(x, 0) + log(1 + exp(-abs(x)))
+    return this->max(zero) + ((-this->abs()).exp() + one).ln();
+}
+
+inline Expression Expression::elu(double alpha) const {
+    const Expression zero(0.0);
+    const Expression one(1.0);
+
+    // Use exp(min(x, 0)) - 1 so positive x does not evaluate exp(x).
+    return this->max(zero) + ((this->min(zero).exp() - one) * Expression(alpha));
+}
+
+inline Expression Expression::selu() const {
+    const Expression zero(0.0);
+    const Expression one(1.0);
+    const Expression scale(1.05070098);
+    const Expression scaleAlpha(1.758099326);
+
+    return (this->max(zero) * scale) + ((this->min(zero).exp() - one) * scaleAlpha);
+}
+
+inline Expression Expression::gelu() const {
+    const Expression one(1.0);
+    const Expression two(2.0);
+    const Expression half(0.5);
+
+    // Match the existing CUDA activation approximation, but use stable tanh helper.
+    const Expression x3 = *this * *this * *this;
+    const Expression inner = (*this + (x3 * Expression(0.044715))) * Expression(0.797884561);
+    return *this * half * (inner.tanh() + one);
+}
+
+inline Expression Expression::swish() const { return *this * this->sigmoid(); }
 
 std::string formatFloatCanonical(double x);
 bool isCommutative(ExprOp op);

--- a/bindings/python/test/core/physical/test_expression_stable_activations.py
+++ b/bindings/python/test/core/physical/test_expression_stable_activations.py
@@ -1,0 +1,177 @@
+import numpy as np
+import pytest
+import thor
+from thor.physical import Expression as ex
+from thor.physical import PhysicalTensor, Stream, Placement, DeviceType, numpy_dtypes
+
+
+def _numpy_storage_dtype(dtype: thor.DataType) -> np.dtype:
+    return numpy_dtypes.from_thor(dtype)
+
+
+def _copy_numpy_to_gpu(arr: np.ndarray, dtype: thor.DataType, stream: Stream, gpu_num: int = 0) -> PhysicalTensor:
+    cpu_placement = Placement(DeviceType.cpu, 0)
+    gpu_placement = Placement(DeviceType.gpu, gpu_num)
+
+    host_desc = PhysicalTensor.Descriptor(dtype, list(arr.shape))
+    host_tensor = PhysicalTensor(cpu_placement, host_desc)
+    host_tensor.numpy()[...] = arr.astype(_numpy_storage_dtype(dtype), copy=False)
+
+    gpu_tensor = PhysicalTensor(gpu_placement, host_desc)
+    gpu_tensor.copy_from_async(host_tensor, stream)
+    return gpu_tensor
+
+
+def _copy_gpu_to_numpy(tensor: PhysicalTensor, stream: Stream) -> np.ndarray:
+    cpu_placement = Placement(DeviceType.cpu, 0)
+    host_tensor = PhysicalTensor(cpu_placement, tensor.get_descriptor())
+    host_tensor.copy_from_async(tensor, stream)
+    stream.synchronize()
+    return host_tensor.numpy().copy()
+
+
+def _run_expr(expr, inputs: dict[str, tuple[np.ndarray, thor.DataType]], gpu_num: int = 0) -> np.ndarray:
+    stream = Stream(gpu_num=gpu_num)
+
+    gpu_inputs = {}
+    for name, (arr, dtype) in inputs.items():
+        gpu_inputs[name] = _copy_numpy_to_gpu(arr, dtype, stream, gpu_num=gpu_num)
+
+    eq = ex.compile(expr, device_num=gpu_num)
+    stamped = eq.stamp(gpu_inputs, stream)
+    stamped.run()
+
+    return _copy_gpu_to_numpy(stamped.output(), stream)
+
+
+def _stable_sigmoid_expr(x):
+    # Equivalent to:
+    #   x >= 0: 1 / (1 + exp(-x))
+    #   x <  0: exp(x) / (1 + exp(x))
+    # but expressed without a branch and without exp of a large positive value.
+    return ex.exp(-ex.max(-x, 0.0)) / (1.0 + ex.exp(-ex.abs(x)))
+
+
+def _stable_tanh_expr(x):
+    return 2.0 * _stable_sigmoid_expr(2.0 * x) - 1.0
+
+
+def _stable_softplus_expr(x):
+    return ex.max(x, 0.0) + ex.ln(1.0 + ex.exp(-ex.abs(x)))
+
+
+def _stable_elu_expr(x, alpha: float = 1.0):
+    return ex.max(x, 0.0) + alpha * (ex.exp(ex.min(x, 0.0)) - 1.0)
+
+
+def _stable_selu_expr(x):
+    return 1.05070098 * ex.max(x, 0.0) + 1.758099326 * (ex.exp(ex.min(x, 0.0)) - 1.0)
+
+
+def _stable_gelu_expr(x):
+    inner = 0.797884561 * (x + 0.044715 * x * x * x)
+    return 0.5 * x * (1.0 + _stable_tanh_expr(inner))
+
+
+def _stable_swish_expr(x):
+    return x * _stable_sigmoid_expr(x)
+
+
+def _stable_sigmoid_np(x: np.ndarray) -> np.ndarray:
+    return np.exp(-np.maximum(-x, 0.0)) / (1.0 + np.exp(-np.abs(x)))
+
+
+def _stable_tanh_np(x: np.ndarray) -> np.ndarray:
+    return 2.0 * _stable_sigmoid_np(2.0 * x) - 1.0
+
+
+def _stable_softplus_np(x: np.ndarray) -> np.ndarray:
+    return np.maximum(x, 0.0) + np.log1p(np.exp(-np.abs(x)))
+
+
+def _stable_elu_np(x: np.ndarray, alpha: float = 1.0) -> np.ndarray:
+    return np.maximum(x, 0.0) + alpha * np.expm1(np.minimum(x, 0.0))
+
+
+def _stable_selu_np(x: np.ndarray) -> np.ndarray:
+    return 1.05070098 * np.maximum(x, 0.0) + 1.758099326 * np.expm1(np.minimum(x, 0.0))
+
+
+def _stable_gelu_np(x: np.ndarray) -> np.ndarray:
+    inner = 0.797884561 * (x + 0.044715 * x * x * x)
+    return 0.5 * x * (1.0 + _stable_tanh_np(inner))
+
+
+def _stable_swish_np(x: np.ndarray) -> np.ndarray:
+    return x * _stable_sigmoid_np(x)
+
+
+@pytest.mark.cuda
+@pytest.mark.parametrize(
+    ("name", "expr_builder", "np_builder"),
+    [
+        ("sigmoid", _stable_sigmoid_expr, _stable_sigmoid_np),
+        ("tanh", _stable_tanh_expr, _stable_tanh_np),
+        ("softplus", _stable_softplus_expr, _stable_softplus_np),
+        ("elu", _stable_elu_expr, _stable_elu_np),
+        ("selu", _stable_selu_expr, _stable_selu_np),
+        ("gelu", _stable_gelu_expr, _stable_gelu_np),
+        ("swish", _stable_swish_expr, _stable_swish_np),
+    ],
+)
+def test_stable_activation_expressions_handle_extreme_fp32_inputs(name, expr_builder, np_builder):
+    del name
+
+    dtype = thor.DataType.fp32
+    x_np = np.array(
+        [-1000.0, -200.0, -100.0, -80.0, -20.0, -3.0, -1.0, 0.0, 1.0, 3.0, 20.0, 80.0, 100.0, 200.0, 1000.0],
+        dtype=np.float32,
+    )
+
+    x = ex.input("x")
+    got = _run_expr(expr_builder(x), {"x": (x_np, dtype)})
+    expected = np_builder(x_np).astype(np.float32)
+
+    assert np.isfinite(got).all()
+    assert np.isfinite(expected).all()
+    np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.cuda
+def test_stable_softplus_does_not_overflow_where_naive_expansion_would():
+    dtype = thor.DataType.fp32
+    x_np = np.array([80.0, 100.0, 200.0, 1000.0], dtype=np.float32)
+
+    x = ex.input("x")
+    got = _run_expr(_stable_softplus_expr(x), {"x": (x_np, dtype)})
+    expected = _stable_softplus_np(x_np).astype(np.float32)
+
+    assert np.isfinite(got).all()
+    np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.cuda
+def test_stable_tanh_saturates_instead_of_overflowing_exp2x():
+    dtype = thor.DataType.fp32
+    x_np = np.array([-1000.0, -200.0, -100.0, 100.0, 200.0, 1000.0], dtype=np.float32)
+
+    x = ex.input("x")
+    got = _run_expr(_stable_tanh_expr(x), {"x": (x_np, dtype)})
+
+    assert np.isfinite(got).all()
+    np.testing.assert_allclose(got, np.array([-1.0, -1.0, -1.0, 1.0, 1.0, 1.0], dtype=np.float32), rtol=0.0, atol=0.0)
+
+
+@pytest.mark.cuda
+def test_stable_elu_and_selu_do_not_evaluate_positive_exp_branch():
+    dtype = thor.DataType.fp32
+    x_np = np.array([80.0, 100.0, 200.0, 1000.0], dtype=np.float32)
+
+    x = ex.input("x")
+    got_elu = _run_expr(_stable_elu_expr(x, alpha=1.25), {"x": (x_np, dtype)})
+    got_selu = _run_expr(_stable_selu_expr(x), {"x": (x_np, dtype)})
+
+    assert np.isfinite(got_elu).all()
+    assert np.isfinite(got_selu).all()
+    np.testing.assert_allclose(got_elu, x_np, rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(got_selu, (1.05070098 * x_np).astype(np.float32), rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
## Summary

This PR makes the activation-expression fusion path numerically safer without touching the large fused CUDA emitter.

Changes included:
- Adds first-class C++ `Expression` helper methods for stable activation-shaped expressions:
  - `sigmoid()`
  - `tanh()`
  - `softplus()`
  - `elu(alpha)`
  - `selu()`
  - `gelu()`
  - `swish()`
- Rewrites API activation fusion to use those helpers for Sigmoid, Tanh, SoftPlus, GELU, SELU, and Swish.
- Rewrites ELU fusion to use `input.elu(alpha)`, preserving the per-instance alpha while avoiding `exp(x)` on the positive branch.
- Adds Python CUDA numerical tests covering extreme FP32 inputs where the prior naive expansions could overflow or produce non-finite values.

## Numerical details

The helper formulas use existing primitive expression ops but avoid overflow-prone expansions:
- sigmoid uses a sign-stable formulation with `exp(-abs(x))`.
- tanh is expressed through stable sigmoid instead of `exp(2x)` directly.
- softplus uses `max(x, 0) + log(1 + exp(-abs(x)))`.
- ELU/SELU use `exp(min(x, 0)) - 1`, so positive values do not evaluate `exp(x)`.
- GELU keeps the existing tanh approximation but routes through the stable tanh helper.

## Notes

This intentionally does **not** add new `ExprOp` enum/codegen primitives yet. It adds stable expression helper methods built from the current primitive op set, which is a smaller and safer PR. Dedicated primitive ops would still be valuable later for graph compactness, simpler autodiff, and potentially more optimized codegen.

I could not run the build or CUDA tests from this environment. The new tests are written against the current Python expression binding surface, so they exercise equivalent stable expression graphs; adding direct Python bindings for the new helper methods would be a useful follow-up.